### PR TITLE
Tags

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -110,6 +110,14 @@ func (e errHaveSeveralInstances) Error() string {
 	return fmt.Sprintf("%s: could not be resolved: have several instances", e.typ)
 }
 
+type errTaggedTypeNotFound struct {
+	uniq string
+}
+
+func (e errTaggedTypeNotFound) Error() string {
+	return fmt.Sprintf("type with tags (%s) not found", e.uniq)
+}
+
 func bug() {
 	panic("you found a bug, please create new issue for this: https://github.com/goava/di/issues/new")
 }

--- a/options.go
+++ b/options.go
@@ -117,6 +117,16 @@ func WithName(name string) ProvideOption {
 	})
 }
 
+// WithTag adds tag-value specification for provided type.
+func WithTag(key string, value string) ProvideOption {
+	return provideOption(func(params *ProvideParams) {
+		if params.Tags == nil {
+			params.Tags = map[string]string{}
+		}
+		params.Tags[key] = value
+	})
+}
+
 // Prototype modifies Provide() behavior. By default, each type resolves as a singleton. This option sets that
 // each type resolving creates a new instance of the type.
 //
@@ -226,12 +236,24 @@ type CompileOption interface {
 // function. Interfaces is a interface that implements a provider result type.
 type ProvideParams struct {
 	Name        string
+	Tags        map[string]string
 	Interfaces  []Interface
 	IsPrototype bool
 }
 
 func (p ProvideParams) apply(params *ProvideParams) {
 	*params = p
+}
+
+func (p *ProvideParams) mergeTags(tags map[string]string) {
+	for k, v := range tags {
+		if p.Tags == nil {
+			p.Tags = map[string]string{}
+		}
+		if _, ok := p.Tags[k]; !ok {
+			p.Tags[k] = v
+		}
+	}
 }
 
 // InvokeOption is a functional option interface that modify invoke behaviour.
@@ -262,9 +284,20 @@ func Name(name string) ResolveOption {
 	})
 }
 
+// Tag todo: documentation
+func Tag(key string, value string) ResolveOption {
+	return resolveOption(func(params *ResolveParams) {
+		if params.Tags == nil {
+			params.Tags = map[string]string{}
+		}
+		params.Tags[key] = value
+	})
+}
+
 // ResolveParams is a resolve parameters.
 type ResolveParams struct {
 	Name string
+	Tags map[string]string
 }
 
 func (p ResolveParams) apply(params *ResolveParams) {

--- a/parameter.go
+++ b/parameter.go
@@ -27,11 +27,11 @@ func (p parameter) String() string {
 func (p parameter) ResolveProvider(c *Container) (provider, error) {
 	plist, exists := c.providers[p.typ]
 	// only one provider of type
-	if exists && plist.Len() == 1 {
+	if exists && plist.Len() == 1 && p.uniq == "" {
 		return plist.ByIndex(0), nil
 	}
 	if exists && p.uniq != "" {
-		return plist.ByUniq(p.uniq), nil
+		return plist.ByUniq(p.uniq)
 	}
 	// named provider
 	if exists && plist.Len() > 1 {

--- a/provider_ctor.go
+++ b/provider_ctor.go
@@ -3,6 +3,7 @@ package di
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/goava/di/internal/reflection"
 )
@@ -83,6 +84,31 @@ func (c providerConstructor) Name() string {
 // ParameterList returns constructor parameter list.
 func (c *providerConstructor) ParameterList() parameterList {
 	return c.params
+}
+
+func (c *providerConstructor) Tags() map[string]string {
+	rt := c.call.Out(0)
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	if rt.Kind() != reflect.Struct {
+		return nil
+	}
+	ft, exists := rt.FieldByName("Tags")
+	if !exists {
+		return nil
+	}
+	fts := string(ft.Tag)
+	tvs := strings.Split(fts, ";")
+	if len(tvs) == 0 {
+		return nil
+	}
+	result := map[string]string{}
+	for _, tv := range tvs {
+		tvlist := strings.Split(tv, ":")
+		result[tvlist[0]] = strings.Replace(tvlist[1], "\"", "", -1)
+	}
+	return result
 }
 
 // Provide provides resultant.

--- a/tag.go
+++ b/tag.go
@@ -1,0 +1,33 @@
+package di
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Tags are embedded expanders for injecting type. Embed it in your injecting type:
+//
+//  type ListConsoleCommand struct {
+//    di.Tags `console.command:"list"`
+//  }
+//
+// And use Resolve() with WithTag() option for fetch all instances
+// have concrete tag-value combination:
+//
+//  var command Command
+//  container.Resolve(&command, WithTag("console.command", "list"))
+type Tags interface{}
+
+func tagsToString(tags map[string]string) string {
+	var keys []string
+	for key := range tags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var kvs []string
+	for _, key := range keys {
+		kvs = append(kvs, fmt.Sprintf("%s:%s", key, tags[key]))
+	}
+	return strings.Join(kvs, ";")
+}


### PR DESCRIPTION
### Implement tag system

Tags are embedded expanders for injecting type. Embed it in your injecting type:

 ```go
type Command interface {
   // ...
}

type ListConsoleCommand struct {
   di.Tags `console.command:"list"`
 }

func NewListConsoleCommand() {
   return &ListConsoleCommand{}
}
```

Provide your type as interface:

```go
c, err := di.New(
   di.Provide(NewListConsoleCommand, di.As(new(Command)))
   // or
   di.Provide(NewListConsoleCommandWithoutTags, di.As(new(Command)), di.WithTag("console.command", "list"))
)
```

And use Resolve() with WithTag() option for fetch instance
with concrete tag-value combination:

```go
 var command Command
 container.Resolve(&command, WithTag("console.command", "list"))
```