### PR TITLE
fix: calling Resolve() on a di.Injectable would overwrite the skip fields

### DIFF
--- a/container.go
+++ b/container.go
@@ -213,8 +213,18 @@ func (c *Container) resolve(ptr Pointer, options ...ResolveOption) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", node, err)
 	}
-	target := reflect.ValueOf(ptr).Elem()
-	target.Set(value)
+
+	rv := reflect.ValueOf(ptr)
+	target := rv.Elem()
+
+	if canInject(rv.Type()) {
+		for index, _ := range parsePopulateFields(target.Type()) {
+			target.Field(index).Set(value.Field(index))
+		}
+	} else {
+		target.Set(value)
+	}
+
 	return nil
 }
 

--- a/container_test.go
+++ b/container_test.go
@@ -1188,6 +1188,11 @@ func TestContainer_Inject(t *testing.T) {
 		require.True(t, extracted)
 		var result *InjectableType
 		require.NoError(t, c.Resolve(&result))
+
+		mux := http.NewServeMux()
+		p := InjectableParameter{Skipped: mux}
+		require.NoError(t, c.Resolve(&p))
+		require.Equal(t, InjectableParameter{Skipped: mux}, p)
 	})
 
 	t.Run("resolving not provided injectable cause error", func(t *testing.T) {


### PR DESCRIPTION
fix: calling Resolve() on a di.Injectable would overwrite the skip fields