### PR TITLE
fix: prefer using "di:" field tags to control injection options to avoid conflicting with tags used by other libraries.

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -80,8 +80,8 @@ type Parameters struct {
 	di.Inject
 	
 	// use tag for the container to know that field need to be injected.
-	Leader *Database `type:"leader"`
-	Follower *Database  `type:"follower"`
+	Leader *Database `di:"type=leader"`
+	Follower *Database  `di:"type=follower"`
 }
 
 // NewService creates new service with provided parameters.
@@ -103,7 +103,7 @@ di.Resolve(&db, di.Tags{"type": "*"})
 
 ### Optional parameters
 
-Also, `di.Inject` with tag `optional` provide ability to skip dependency
+Also, `di.Inject` with tag `di:"optional"` provide ability to skip dependency
 if it not exists in the container.
 
 ```go
@@ -111,7 +111,7 @@ if it not exists in the container.
 type ServiceParameter struct {
 	di.Inject
 	
-	Logger *Logger `optional:"true"`
+	Logger *Logger `di:"optional"`
 }
 ```
 
@@ -125,21 +125,21 @@ You can use tagged and optional together.
 type ServiceParameter struct {
 	di.Inject
 	
-	StdOutLogger *Logger `type:"stdout"`
-	FileLogger   *Logger `type:"file" optional:"true"`
+	StdOutLogger *Logger `di:"type=stdout"`
+	FileLogger   *Logger `di:"type=file,optional"`
 }
 ```
 
-If you need to skip fields injection use `skip:"true"` tags for this:
+If you need to skip fields injection use `di:"skip"` tags for this:
 
 ```go
 // ServiceParameter
 type ServiceParameter struct {
 	di.Inject
 	
-	StdOutLogger *Logger    `type:"stdout"`
-	FileLogger   *Logger    `type:"file" optional:"true"`
-	SkipField    *SomeType  `skip:"true"` // injection skipped
+	StdOutLogger *Logger    `di:"type=stdout"`
+	FileLogger   *Logger    `di:"type=file,optional"`
+	SkipField    *SomeType  `di:"skip"` // injection skipped
 }
 ```
 
@@ -158,7 +158,7 @@ type Controller struct {
     // fields must be public
     // tag lets to specify fields need to be injected
     Users   UserService
-    Friends FriendsService  `type:"cached"`
+    Friends FriendsService  `di:"type=cached"`
 }
 
 // NewController creates controller.

--- a/node.go
+++ b/node.go
@@ -27,7 +27,7 @@ func newConstructorNode(ctor interface{}) (*node, error) {
 		if !ok {
 			return nil, fmt.Errorf("tags usage error: need to embed di.Tags without field name")
 		}
-		field, ok := inspectStructField(f)
+		field, ok := inspectStructField(tmp, f)
 		if ok {
 			tags = field.tags
 		}


### PR DESCRIPTION
fix: prefer using "di:" field tags to control injection options to avoid conflicting with tags used by other libraries.

old style is still supported but generates a deprecation warning like:
```
2021/07/16 13:40:19 Deprecation warning: please replace the field tags on 'Server.Tags' with: di:"http=true,server=true"
```

this fixes #37 