### PR TITLE
feat: add a ProvideOptions method for di initialization (solve #51)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -11,9 +11,10 @@ var (
 )
 
 var (
-	errInvalidInvocationSignature = errors.New("invalid invocation signature")
-	errCycleDetected              = errors.New("cycle detected")
-	errFieldsNotSupported         = errors.New("fields not supported")
+	errInvalidInvocationSignature     = errors.New("invalid invocation signature")
+	errInvalidOptionsFactorySignature = errors.New("invalid options factory signature")
+	errCycleDetected                  = errors.New("cycle detected")
+	errFieldsNotSupported             = errors.New("fields not supported")
 )
 
 // knownError return true if err is library known error.

--- a/factory.go
+++ b/factory.go
@@ -1,0 +1,21 @@
+package di
+
+import "reflect"
+
+// validateOptionsFactory validates function.
+func validateOptionsFactory(fn function) bool {
+	if fn.NumOut() == 1 && isOptionsSlice(fn.Out(0)) {
+		return true
+	}
+	if fn.NumOut() == 2 && isOptionsSlice(fn.Out(0)) && isError(fn.Out(1)) {
+		return true
+	}
+	return false
+}
+
+func isOptionsSlice(typ reflect.Type) bool {
+	optType := reflect.TypeOf((*Option)(nil)).Elem()
+	return typ.Kind() == reflect.Slice &&
+		typ.Elem().Kind() == reflect.Interface &&
+		typ.Elem().Implements(optType)
+}

--- a/options.go
+++ b/options.go
@@ -38,6 +38,17 @@ func ProvideValue(value Value, options ...ProvideOption) Option {
 	})
 }
 
+func ProvideOptions(factory OptionsFactory, options ...ProvideOption) Option {
+	frame := stacktrace(0)
+	return option(func(c *diopts) {
+		c.provideOptions = append(c.provideOptions, provideOptionsOptions{
+			frame,
+			factory,
+			options,
+		})
+	})
+}
+
 // Constructor is a function with follow signature:
 //
 //	func NewHTTPServer(addr string, handler http.Handler) (server *http.Server, cleanup func(), err error) {
@@ -290,4 +301,10 @@ type resolveOptions struct {
 	frame   callerFrame
 	target  Pointer
 	options []ResolveOption
+}
+
+type provideOptionsOptions struct {
+	frame   callerFrame
+	fn      OptionsFactory
+	options []ProvideOption
 }


### PR DESCRIPTION
ProvideOptions is used to have a method receive dependencies and return other dependencies to be registered. This is useful to do conditional factories that return a variable number of dependencies.

Once I get confirmation that the code looks good, I will add the tests and doc.

Another option would be to simplify by not using a separate method, but by changing the `Provide` method to handle the special case of a constructor returning `di.Option` or `[]di.Option`.